### PR TITLE
Updated plugin to support array with paths instead of single path

### DIFF
--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -7,27 +7,28 @@ module Fastlane
             def self.run(params)
             api_token = params[:api_token]
             
-            if params[:dsym_path].end_with?('.zip')
-            dsym_zip_path = params[:dsym_path].shellescape
-            else
-            dsym_path = params[:dsym_path]
-            dsym_zip_path = ZipAction.run(path: dsym_path).shellescape
-        end
-        
-        endpoint = 'https://api.instabug.com/api/ios/v1/dsym'
-        
-        command =  "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F dsym=@\"#{dsym_zip_path}\" -F token=\"#{api_token}\""
-        
-        UI.verbose command
-        
-        return command if Helper.test?
-        
-        result = Actions.sh(command)
-        if result == "200"
-        UI.success 'dSYM is successfully uploaded to Instabug 🤖'
-        else
-        UI.error "Something went wrong during Instabug dSYM upload. Status code is #{result}"
-    end
+            endpoint = "https://api.instabug.com/api/sdk/v3/symbols_files"
+            command = "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F os=\"ios\" -F application_token=\"#{api_token}\" -F symbols_file="
+            dsym_paths = params[:dsym_path].uniq
+            
+            curlCommand = ""
+            
+            dsym_paths.each do |file_path|
+                curlCommand += build_single_file_command(command, file_path)
+                if file_path != dsym_paths.last
+                    curlCommand += " | "
+                end
+            end
+    
+    UI.verbose curlCommand
+    return curlCommand if Helper.test?
+    
+    result = Actions.sh(curlCommand)
+    if result == "200"
+    UI.success 'dSYM is successfully uploaded to Instabug 🤖'
+    else
+    UI.error "Something went wrong during Instabug dSYM upload. Status code is #{result}"
+end
 end
 
 def self.description
@@ -56,20 +57,27 @@ FastlaneCore::ConfigItem.new(key: :api_token,
                              UI.user_error!("No API token for InstabugAction given, pass using `api_token: 'token'`") unless value && !value.empty?
                              end),
 FastlaneCore::ConfigItem.new(key: :dsym_path,
-                             env_name: 'FL_INSTABUG_DSYM_PATH',
-                             description: 'Path to *.dSYM file',
-                             default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
-                             is_string: true,
-                             optional: true,
-                             verify_block: proc do |value|
-                             UI.user_error!("dSYM file doesn't exists") unless File.exist?(value)
-                             end)
+                             type: Array,
+                             description: 'Array of paths to *.dSYM.zip files',
+                             default_value: Actions.lane_context[SharedValues::
+                             ]),
 ]
 end
 
 def self.is_supported?(platform)
 platform == :ios
 true
+end
+
+private
+
+def self.build_single_file_command(command, dsym_path)
+if dsym_path.end_with?('.zip')
+    file_path = dsym_path.shellescape
+    else
+    file_path = ZipAction.run(path: dsym_path).shellescape
+end
+return command + "@\"#{file_path}\""
 end
 end
 end

--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -59,8 +59,7 @@ FastlaneCore::ConfigItem.new(key: :api_token,
 FastlaneCore::ConfigItem.new(key: :dsym_path,
                              type: Array,
                              description: 'Array of paths to *.dSYM.zip files',
-                             default_value: Actions.lane_context[SharedValues::
-                             ]),
+                             default_value: Actions.lane_context[SharedValues::DSYM_PATHS]),
 ]
 end
 

--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -5,31 +5,36 @@ module Fastlane
     module Actions
         class InstabugOfficialAction < Action
             def self.run(params)
-            api_token = params[:api_token]
-            
-            endpoint = "https://api.instabug.com/api/sdk/v3/symbols_files"
-            command = "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F os=\"ios\" -F application_token=\"#{api_token}\" -F symbols_file="
-            dsym_paths = params[:dsym_path].uniq
-            
-            curlCommand = ""
-            
-            dsym_paths.each do |file_path|
-                curlCommand += build_single_file_command(command, file_path)
-                if file_path != dsym_paths.last
-                    curlCommand += " | "
+                api_token = params[:api_token]
+
+                endpoint = "https://api.instabug.com/api/sdk/v3/symbols_files"
+                command = "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F os=\"ios\" -F application_token=\"#{api_token}\" -F symbols_file="
+
+                curlCommand = ""
+                single_path = params[:dsym_path]
+
+                 if single_path != nil
+                    curlCommand += build_single_file_command(command, single_path)
+                 else
+                    dsym_paths = params[:dsym_array_paths].uniq
+                    dsym_paths.each do |file_path|
+                        curlCommand += build_single_file_command(command, file_path)
+                        if file_path != dsym_paths.last
+                            curlCommand += " | "
+                        end
+                    end
+                 end
+
+                UI.verbose curlCommand
+                return curlCommand if Helper.test?
+
+                result = Actions.sh(curlCommand)
+                if result == "200"
+                    UI.success 'dSYM is successfully uploaded to Instabug 🤖'
+                else
+                    UI.error "Something went wrong during Instabug dSYM upload. Status code is #{result}"
                 end
             end
-    
-    UI.verbose curlCommand
-    return curlCommand if Helper.test?
-    
-    result = Actions.sh(curlCommand)
-    if result == "200"
-    UI.success 'dSYM is successfully uploaded to Instabug 🤖'
-    else
-    UI.error "Something went wrong during Instabug dSYM upload. Status code is #{result}"
-end
-end
 
 def self.description
 "upload dsyms to fastlane"
@@ -56,10 +61,20 @@ FastlaneCore::ConfigItem.new(key: :api_token,
                              verify_block: proc do |value|
                              UI.user_error!("No API token for InstabugAction given, pass using `api_token: 'token'`") unless value && !value.empty?
                              end),
-FastlaneCore::ConfigItem.new(key: :dsym_path,
+FastlaneCore::ConfigItem.new(key: :dsym_array_paths,
                              type: Array,
+                             optional: true,
                              description: 'Array of paths to *.dSYM.zip files',
                              default_value: Actions.lane_context[SharedValues::DSYM_PATHS]),
+FastlaneCore::ConfigItem.new(key: :dsym_path,
+                             env_name: 'FL_INSTABUG_DSYM_PATH',
+                             description: 'Path to *.dSYM file',
+                             default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
+                             is_string: true,
+                             optional: true,
+                             verify_block: proc do |value|
+                                 UI.user_error!("dSYM file doesn't exists") unless File.exist?(value)
+                             end)
 ]
 end
 


### PR DESCRIPTION
Since `download_dsyms` fastlane plugin returns an array of paths I had to update the plugin to be able to parse that array and upload each of file separately