### PR TITLE
Fix hang issue when unarchiving

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-instabug_official (0.3)
+    fastlane-plugin-instabug_official (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -113,9 +113,10 @@ module Fastlane
       def self.copy_dsym_paths_into_directory(dsym_paths, directory_path)
         dsym_paths.each do |path|
           if File.extname(path) == '.dSYM'
-            FileUtils.copy_entry(path, "#{directory_path}/#{File.basename(path)}") if File.exist?(path)
+            destination_path = "#{directory_path}/#{File.basename(path)}"
+            FileUtils.copy_entry(path, destination_path) if File.exist?(path)
           else
-            Actions.sh("unzip #{path} -d #{directory_path}")
+            Actions.sh("unzip -n #{path} -d #{directory_path}")
           end
         end
       end

--- a/lib/fastlane/plugin/instabug_official/version.rb
+++ b/lib/fastlane/plugin/instabug_official/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module InstabugOfficial
-    VERSION = "0.3"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
## Description of the change
> Fixes an issue when uploading dSYM files that have duplicate UUIDs, unarchiving would then cause the script to hang
Fixed by adding `-n` flag to `unzip` command
## Checklists
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer. 
- [ ] Changes have been reviewed by at least one other engineer