### PR TITLE
Fix shell failure because of spaces in paths

### DIFF
--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'fastlane/action'
 require_relative '../helper/instabug_official_helper'
+require 'shellwords'
 
 module Fastlane
   module Actions
@@ -115,7 +116,7 @@ module Fastlane
           if File.extname(path) == '.dSYM'
             FileUtils.copy_entry(path, "#{directory_path}/#{File.basename(path)}") if File.exist?(path)
           else
-            Actions.sh("unzip #{path} -d #{directory_path}")
+            Actions.sh("unzip #{Shellwords.shellescape(path)} -d #{Shellwords.shellescape(directory_path)}")
           end
         end
       end
@@ -126,7 +127,7 @@ module Fastlane
                     else
                       ZipAction.run(path: dsym_path).shellescape
                     end
-        command + "@\"#{file_path}\""
+        command + "@\"#{Shellwords.shellescape(file_path)}\""
       end
     end
   end

--- a/lib/fastlane/plugin/instabug_official/version.rb
+++ b/lib/fastlane/plugin/instabug_official/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module InstabugOfficial
-    VERSION = "0.3"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
## Description of the change
Fix failures to execute shell command because of unescaped spaces 

## Checklists
### Code review 
- [x]  This pull request has a descriptive title and information useful to a reviewer. 
- [x] Changes have been reviewed by at least one other engineer