### PR TITLE
[INSD-5722] Fix/incompatibility with fastlane v2.190

### DIFF
--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -126,7 +126,7 @@ module Fastlane
         file_path = if dsym_path.end_with?('.zip')
                       dsym_path.shellescape
                     else
-                      ZipAction.run(path: dsym_path).shellescape
+                      ZipAction.run(path: dsym_path, include: [], exclude: []).shellescape
                     end
         command + "@\"#{Shellwords.shellescape(file_path)}\""
       end

--- a/lib/fastlane/plugin/instabug_official/version.rb
+++ b/lib/fastlane/plugin/instabug_official/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module InstabugOfficial
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end


### PR DESCRIPTION
## Description of the change

- After updating to fastlane to v2.190 our script was no longer working producing errors related to integrating with fastlane.
- Some mandatory attributes with no default value were needed to be passed to a fastlane method call.

## Checklists
### Code review 
- [x]  This pull request has a descriptive title and information useful to a reviewer. 
Issue [link](https://instabug.atlassian.net/browse/INSD-5722)