### PR TITLE
[INSD-8974] Fix/error upload symbols directory path with spaces

### DIFF
--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -124,11 +124,11 @@ module Fastlane
 
       def self.build_single_file_command(command, dsym_path)
         file_path = if dsym_path.end_with?('.zip')
-                      dsym_path.shellescape
+                      dsym_path
                     else
-                      ZipAction.run(path: dsym_path, include: [], exclude: []).shellescape
+                      ZipAction.run(path: dsym_path, include: [], exclude: [])
                     end
-        command + "@\"#{Shellwords.shellescape(file_path)}\""
+        command + "@\"#{file_path}\""
       end
     end
   end

--- a/lib/fastlane/plugin/instabug_official/version.rb
+++ b/lib/fastlane/plugin/instabug_official/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module InstabugOfficial
-    VERSION = "0.3.3"
+    VERSION = "0.3.4"
   end
 end


### PR DESCRIPTION
## Description of the change
Fix the error when uploading symbol files from a path that contains spaces in directory names.
